### PR TITLE
Use `center()` instead of `centroid()` as the symbol location to work…

### DIFF
--- a/common/WhirlyGlobeLib/src/MapboxVectorStyleSymbol.cpp
+++ b/common/WhirlyGlobeLib/src/MapboxVectorStyleSymbol.cpp
@@ -507,7 +507,7 @@ void MapboxVectorLayerSymbol::buildObjects(PlatformThreadInfo *inst,
                     // Place the marker at the middle of the polygon.
                     // Note that if there are multiple shapes, this will be recalculated unnecessarily.
                     Point2d middle;
-                    if (!vecObj->centroid(middle)) {
+                    if (!vecObj->center(middle)) {
 #if DEBUG
                         wkLogLevel(Warn, "MapboxVectorLayerSymbol: Failed to compute centroid of areal shape");
 #endif


### PR DESCRIPTION
… around sensitivity to open/closed polygon data.

See also: #32